### PR TITLE
Error highlighting

### DIFF
--- a/Wordsmith/Configuration.cs
+++ b/Wordsmith/Configuration.cs
@@ -112,6 +112,13 @@ public class Configuration : IPluginConfiguration
     /// The file to be loaded into Lang dictionary.
     /// </summary>
     public string DictionaryFile { get; set; } = "lang_en";
+
+    /// <summary>
+    /// If enabled, uses a custom label layout to display highlighted text.
+    /// </summary>
+    public bool EnableSpellingErrorHighlighting { get; set; } = true;
+
+    public Vector4 SpellingErrorHighlightColor { get; set; } = new( 0.9f, 0.2f, 0.2f, 1f );
     #endregion
 
     #region Linkshell Settings
@@ -146,6 +153,8 @@ public class Configuration : IPluginConfiguration
         ScratchPadTextEnterBehavior = 0;
         ScratchPadMaximumTextLength = 4096;
         ReplaceDoubleSpaces = true;
+        EnableSpellingErrorHighlighting = true;
+        SpellingErrorHighlightColor = new( 0.9f, 0.2f, 0.2f, 1f );
         DetectHeaderInput = true;
 
         // Spell Check settings

--- a/Wordsmith/Extensions/Extensions.cs
+++ b/Wordsmith/Extensions/Extensions.cs
@@ -48,7 +48,7 @@ public static class Extensions
     /// Capitalizes the first letter in a string.
     /// </summary>
     /// <param name="s">The string to capitalize the first letter of.</param>
-    /// <returns></returns>
+    /// <returns>A <see cref="string"/> with the first letter capitalized.</returns>
     public static string CaplitalizeFirst(this string s)
     {
         // If the length is one, just change the char and send it back.
@@ -64,6 +64,11 @@ public static class Extensions
         return s;
     }
 
+    /// <summary>
+    /// Spaces a string by capital letters. Useful for adding spaces to PascalCasing
+    /// </summary>
+    /// <param name="s">String to space.</param>
+    /// <returns>A properly spaced <see cref="string"/></returns>
     public static string SpaceByCaps(this string s)
     {
         // If there aren't at least two characters then return.
@@ -92,7 +97,7 @@ public static class Extensions
     /// Removes all double spaces from a string.
     /// </summary>
     /// <param name="s">The string to remove double spaces from.</param>
-    /// <returns></returns>
+    /// <returns><see cref="string"/> with double-spacing fixed.</returns>
     public static string FixSpacing(this string s)
     {
         // Start by initially running the replace command.
@@ -111,12 +116,25 @@ public static class Extensions
         return s;
     }
 
+    /// <summary>
+    /// Removes all double spaces from a string.
+    /// </summary>
+    /// <param name="s">The string to remove double spaces from.</param>
+    /// <param name="cursorPos">A reference to a text cursor to be manipulated.</param>
+    /// <returns><see cref="string"/> with double-spacing fixed.</returns>
     public static string FixSpacing(this string s, ref int cursorPos)
     {
+        int idx;
         do
         {
             // Get the position of the first double space.
-            int idx = s.IndexOf("  ");
+            idx = s.IndexOf("  ");
+            if ( idx == cursorPos - 1 )
+            {
+                idx = s[cursorPos..^0].IndexOf( "  " );
+                if ( idx > -1 )
+                    idx += cursorPos;
+            }
 
             // If the index is greater than -1;
             if (idx > -1)
@@ -134,7 +152,7 @@ public static class Extensions
                 if (idx <= cursorPos)
                     cursorPos -= 1;
             }
-        } while (s.Contains("  "));
+        } while (idx > -1);
 
         return s;
     }
@@ -145,7 +163,7 @@ public static class Extensions
     /// <typeparam name="T">Generic Type</typeparam>
     /// <param name="array">The array to find the object in.</param>
     /// <param name="obj">The object to locate within the array.</param>
-    /// <returns></returns>
+    /// <returns><see cref="int"/> index of <typeparamref name="T"/> in array or -1 if not found.</returns>
     public static int IndexOf<T>(this T[] array, T obj)
     {
         // Iterate and compare each item and return the index if

--- a/Wordsmith/Gui/DebugUI.cs
+++ b/Wordsmith/Gui/DebugUI.cs
@@ -14,6 +14,8 @@ internal sealed class DebugUI : Window
             MaximumSize = ImGuiHelpers.ScaledVector2(9999, 9999)
         };
 
+        this.Flags |= ImGuiWindowFlags.HorizontalScrollbar;
+
 #if DEBUG
         PluginLog.LogDebug( $"DebugUI created." );
 #endif
@@ -25,7 +27,7 @@ internal sealed class DebugUI : Window
             if (w != null && w is ScratchPadUI pad)
             {
                 // Draw the pad info
-                ImGui.TextWrapped( $"{pad.GetDebugString()}" );
+                ImGui.Text( $"{pad.GetDebugString()}" );
                 ImGui.Separator();
                 ImGui.Spacing();
             }

--- a/Wordsmith/Gui/DebugUI.cs
+++ b/Wordsmith/Gui/DebugUI.cs
@@ -5,7 +5,9 @@ using ImGuiNET;
 namespace Wordsmith.Gui;
 
 internal sealed class DebugUI : Window
-{ 
+{
+    internal static bool ShowWordIndex = false;
+
     public DebugUI() : base( $"{Wordsmith.AppName} - Debug" )
     {
         this.SizeConstraints = new()
@@ -22,6 +24,7 @@ internal sealed class DebugUI : Window
     }
     public override void Draw()
     {
+        ImGui.Checkbox( "Show Word Index", ref ShowWordIndex );
         foreach (Window w in WordsmithUI.Windows)
         {
             if (w != null && w is ScratchPadUI pad)

--- a/Wordsmith/Gui/ScratchPadUI.cs
+++ b/Wordsmith/Gui/ScratchPadUI.cs
@@ -520,19 +520,26 @@ public class ScratchPadUI : Window
     protected void DrawChunkItem(string text)
     {
         // Split it into words.
-        string[] words = text.Split(" ");
-
+        string[] words = text.Replace(GetFullChatHeader(), "").Split(" ", StringSplitOptions.RemoveEmptyEntries);
         float width = 0f;
+
+        bool sameLine = false;
+        if ( GetFullChatHeader().Length > 0 )
+        {
+            ImGui.Text( GetFullChatHeader() );
+            width += ImGui.CalcTextSize( GetFullChatHeader() ).X;
+            sameLine = true;
+        }
         for (int i = 0; i < words.Length; ++i)
         {
             string word = words[i];
-#if DEBUG
-            word = $"[{i}]{word}";
-#endif
+
+            if (DebugUI.ShowWordIndex)
+                word = $"[{i}]{word}";
 
             float objWidth = ImGui.CalcTextSize(word).X;
             width += objWidth+(5*ImGuiHelpers.GlobalScale);
-            if ( i > 0 && width < ImGui.GetWindowContentRegionMax().X )
+            if ( (i > 0 || sameLine) && width < ImGui.GetWindowContentRegionMax().X )
                 ImGui.SameLine( 0, 2 * ImGuiHelpers.GlobalScale );
             else
                 width = objWidth;

--- a/Wordsmith/Gui/ScratchPadUI.cs
+++ b/Wordsmith/Gui/ScratchPadUI.cs
@@ -129,11 +129,19 @@ public class ScratchPadUI : Window
     /// </summary>
     protected CancellationTokenSource? _cancellationTokenSource;
 
+    private Dictionary<string, (string Title, string Message)> _debugLines = new();
     internal string GetDebugString()
     {
         string result = $"Pad ID: {this.ID}\nScratchString: {this.ScratchString}\nOOC {_useOOC}\nChunks[{_chunks?.Length ?? 0}]:";
         foreach ( string s in _chunks ?? Array.Empty<string>() )
             result += $"\n\t - {s.Replace( "\r", "\\r" ).Replace( "\n", "\\n" )}";
+        result += $"\n\nCorrections:";
+        foreach ( Data.WordCorrection wc in _corrections )
+            result += $"\n\t [{wc.Index}]\t{wc.Original}";
+
+        foreach(KeyValuePair<string, (string Title, string Message)> kvp in _debugLines )
+            result += $"\n{kvp.Value.Title}\n\t- {kvp.Value.Message}";
+
         return result;
     }
 
@@ -479,16 +487,21 @@ public class ScratchPadUI : Window
             {
                 for (int i = 0; i < (_chunks?.Length ?? 0); ++i)
                 {
-                    // If not the first chunk, add a spacing.
-                    if (i > 0)
+                    //// If not the first chunk, add a spacing.
+                    if ( i > 0 )
                         ImGui.Spacing();
 
                     // Put a separator at the top of the chunk.
                     ImGui.Separator();
 
-                    // Set width and display the chunk.
-                    ImGui.SetNextItemWidth(-1);
-                    ImGui.TextWrapped(_chunks![i]);
+                    if (Wordsmith.Configuration.EnableSpellingErrorHighlighting && _corrections.Count > 0)
+                        DrawChunkItem( _chunks![i] );
+                    else
+                    {
+                        // Set width and display the chunk.
+                        ImGui.SetNextItemWidth( -1 );
+                        ImGui.TextWrapped( _chunks![i] );
+                    }
                 }
             }
             // If it's disabled and the user has enabled UseOldSingleLineInput then we still need to draw a display for them.
@@ -502,6 +515,32 @@ public class ScratchPadUI : Window
         }
         ImGui.Separator();
         ImGui.Spacing();
+    }
+
+    protected void DrawChunkItem(string text)
+    {
+        // Split it into words.
+        string[] words = text.Split(" ");
+
+        float width = 0f;
+        for (int i = 0; i < words.Length; ++i)
+        {
+            string word = words[i];
+#if DEBUG
+            word = $"[{i}]{word}";
+#endif
+
+            float objWidth = ImGui.CalcTextSize(word).X;
+            width += objWidth+(5*ImGuiHelpers.GlobalScale);
+            if ( i > 0 && width < ImGui.GetWindowContentRegionMax().X )
+                ImGui.SameLine( 0, 2 * ImGuiHelpers.GlobalScale );
+            else
+                width = objWidth;
+            if ( _corrections?.Count > 0 && _corrections[0].Index == i)
+                ImGui.TextColored( Wordsmith.Configuration.SpellingErrorHighlightColor, word );
+            else
+                ImGui.Text(word);
+        }
     }
 
     /// <summary>
@@ -525,8 +564,9 @@ public class ScratchPadUI : Window
             ref _scratch, (uint)Wordsmith.Configuration.ScratchPadMaximumTextLength,
             v,
             ImGuiInputTextFlags.CallbackEdit |
+            ImGuiInputTextFlags.CallbackAlways |
             ImGuiInputTextFlags.EnterReturnsTrue,
-            OnTextEdit))
+            OnTextCallback))
         {
             // If the user hits enter, run the user-defined action.
             if (Wordsmith.Configuration.ScratchPadTextEnterBehavior == Enums.EnterKeyAction.SpellCheck)
@@ -734,6 +774,8 @@ public class ScratchPadUI : Window
         // Copy the string to the history variable.
         _clearedScratch = _scratch;
 
+        _corrections = new();
+
         // Clear scratch.
         _scratch = "";
     }
@@ -797,7 +839,8 @@ public class ScratchPadUI : Window
 
             // Break apart the words in the sentence.
             string[] words = _scratch
-                .Replace('\n', ' ')
+                .Replace(SPACED_WRAP_MARKER+'\n', " ")
+                .Replace(NOSPACE_WRAP_MARKER+'\n', "")
                 .Split(' ');
 
             // Replace the content of the word in question.
@@ -811,8 +854,21 @@ public class ScratchPadUI : Window
             // Replace the user's original text with the new words.
             _scratch = string.Join(' ', words);
 
+            // If the user replaces a single word with multiple words, we need to increment the remaining index.
+            if ( _replaceText.Split( " " ).Length > 1 )
+            {
+                foreach (Data.WordCorrection wc in _corrections)
+                    wc.Index += _replaceText.Split( " " ).Length - 1;
+            }
+            else if (_replaceText == "")
+            {
+                foreach ( Data.WordCorrection wc in _corrections )
+                    --wc.Index;
+            }
+
             // Clear out replacement text.
             _replaceText = "";
+
 
             int ignore = 0;
             // Rewrap the text string.
@@ -838,6 +894,40 @@ public class ScratchPadUI : Window
             _cancellationTokenSource?.Cancel();
             WordsmithUI.RemoveWindow(this);
         }
+    }
+
+    public unsafe int OnTextCallback( ImGuiInputTextCallbackData* data )
+    {
+        if ( data->EventFlag == ImGuiInputTextFlags.CallbackAlways )
+        {
+            // If the user hits the right key and this makes it so that a \r character is to the left of the cursor
+            // move the cursor again until passed all \r keys. This will make the cursor go from \r|\r\n to \r\r|\n
+            // then to \r\r\n|
+            if (ImGui.IsKeyPressed(ImGui.GetKeyIndex(ImGuiKey.RightArrow)))
+            {
+                while ( data->CursorPos < data->BufTextLen && data->Buf[(data->CursorPos - 1 > 0 ? data->CursorPos - 1 : 0)] == '\r' )
+                {
+                    data->CursorPos++;
+#if DEBUG
+                    PluginLog.LogDebug( $"Moved cursor to the right." );
+#endif
+                }
+            }
+            if (data->CursorPos > 0)
+            {
+                while ( data->CursorPos > 0 && data->Buf[data->CursorPos - 1] == '\r' )
+                {
+                    data->CursorPos--;
+#if DEBUG
+                    PluginLog.LogDebug( "Moved cursor to the left." );
+#endif
+                }
+            }
+        }
+        else
+            return OnTextEdit( data );
+
+        return 0;
     }
 
     /// <summary>
@@ -1064,61 +1154,6 @@ public class ScratchPadUI : Window
         // Trim any return carriages off the end. This can happen if the user
         // backspaces a new line character off of the end.
         text = text.TrimEnd('\r');
-
-        // If the user enters any character at the end of a line it will
-        // break the wrap marker so scan for any broken wrap makers.
-        for (int i = 0; i < text.Length; ++i)
-        {
-            // Check for a broken wrap marker \r\r#\n where # is any char besides \n.
-            if (
-                i < text.Length - SPACED_WRAP_MARKER.Length + 1 &&
-                text[i..(i + SPACED_WRAP_MARKER.Length)] == SPACED_WRAP_MARKER &&
-                text[i + SPACED_WRAP_MARKER.Length] != '\n' &&
-                text[i + SPACED_WRAP_MARKER.Length + 1] == '\n')
-            {
-                // if the character before the cursor position is a new line
-                if (text[i+ SPACED_WRAP_MARKER.Length + 1] == '\n')
-                {
-                    // A character has been wedged between the return
-                    // carriage characters and the new line character.
-
-                    // First, remove the new line characters.
-                    text = text[0..i] + text[(i + SPACED_WRAP_MARKER.Length)..^0];
-
-                    // Now replace the new line with a space.
-                    text = text[0..(i+1)] + " " + text[(i+SPACED_WRAP_MARKER.Length)..^0];
-
-                    // Subtract the length of the spaced marker from the cursor position
-                    if (cursorPos > i)
-                        cursorPos -= 2;
-                }
-            }
-
-            // Check for a broken no-space wrap maker \r#\n where # is any char besides \n.
-            // It's important to also check that
-            else if (
-                i < text.Length - NOSPACE_WRAP_MARKER.Length + 1 &&      // Ensure that there are enough indices remaining.
-                text[i..(i + NOSPACE_WRAP_MARKER.Length)] == NOSPACE_WRAP_MARKER &&     // If text starts with the no space marker and
-                text[i + NOSPACE_WRAP_MARKER.Length] != '\n' &&                         // If the next character is not a new line
-                text[i + NOSPACE_WRAP_MARKER.Length + 1] == '\n' &&                     // If the character after that is a new line
-                text[i..(i + SPACED_WRAP_MARKER.Length)] != SPACED_WRAP_MARKER)         // If the characters are not the SPACED marker.
-            {
-
-                // Remove the \r from the text
-                text = text[0..i] + text[(i + 1)..^0];
-
-                // Remove the \n from the text.
-                text = text[0..(i + 1)] + text[(i + 2)..^0];
-
-                // Subtract the length of the spaced marker from the cursor position
-                if (cursorPos > i)
-                    cursorPos -= 2;
-
-                // Need to iterate that the same index because we have already removed the
-                // current char at i.
-                i -= 1;
-            }
-        }
 
         // Replace all wrap markers with spaces and adjust cursor offset. Do this before
         // all non-spaced wrap markers because the Spaced marker contains the nonspaced marker

--- a/Wordsmith/Gui/SettingsUI.cs
+++ b/Wordsmith/Gui/SettingsUI.cs
@@ -31,6 +31,9 @@ public sealed class SettingsUI : Window
 
     // Dictionary Settings
     private bool _fixDoubleSpace = Wordsmith.Configuration.ReplaceDoubleSpaces;
+    private bool _spellingErrorHighlight = Wordsmith.Configuration.EnableSpellingErrorHighlighting;
+    private Vector4 _backupColor = new();
+    private Vector4 _spellingErrorColor = Wordsmith.Configuration.SpellingErrorHighlightColor;
     private string _dictionaryFilename = Wordsmith.Configuration.DictionaryFile;
 
     // Linkshell Settings
@@ -314,7 +317,28 @@ public sealed class SettingsUI : Window
                         this._dictionaryFilename = files[selection];
                 }
                 ImGui.Separator();
+                bool highlightColorPopup = false;
+                if ( this._spellingErrorHighlight )
+                    highlightColorPopup = ImGui.ColorButton( "##ColorPreviewButton", this._spellingErrorColor );
+                else
+                    ImGui.ColorButton( "##ColorPreviewButtonDisabled", new( 0.2f, 0.2f, 0.2f, 0.5f ), ImGuiColorEditFlags.NoTooltip);
+                if ( highlightColorPopup )
+                {
+                    ImGui.OpenPopup( "SettingsUIErrorHighlightingColorPickerPopup" );
+                    this._backupColor = this._spellingErrorColor;
+                }
+                if ( ImGui.BeginPopup( "SettingsUIErrorHighlightingColorPickerPopup" ) )
+                {
+
+                    if ( ImGui.ColorPicker4( "##SettingsUIErrorHighlightingPicker", ref this._backupColor ) )
+                        this._spellingErrorColor = this._backupColor;
+
+                    ImGui.EndPopup();
+                }
+                ImGui.SameLine();
+                ImGui.Checkbox( "Enable spelling error highlighting.##SettingsUICheckbox", ref this._spellingErrorHighlight );
                 ImGui.Spacing();
+                ImGui.Separator();
 
                 // Custom Dictionary Table
                 if (ImGui.BeginTable($"CustomDictionaryEntriesTable", 2, ImGuiTableFlags.BordersH))
@@ -485,6 +509,8 @@ public sealed class SettingsUI : Window
 
         // Spell Check Settings
         this._fixDoubleSpace = Wordsmith.Configuration.ReplaceDoubleSpaces;
+        this._spellingErrorHighlight = Wordsmith.Configuration.EnableSpellingErrorHighlighting;
+        this._spellingErrorColor = Wordsmith.Configuration.SpellingErrorHighlightColor;
         this._dictionaryFilename = Wordsmith.Configuration.DictionaryFile;
 
         // Linkshell Settings
@@ -550,6 +576,12 @@ public sealed class SettingsUI : Window
         // Spell Check settings.
         if (this._fixDoubleSpace != Wordsmith.Configuration.ReplaceDoubleSpaces)
             Wordsmith.Configuration.ReplaceDoubleSpaces = this._fixDoubleSpace;
+
+        if ( this._spellingErrorHighlight != Wordsmith.Configuration.EnableSpellingErrorHighlighting )
+            Wordsmith.Configuration.EnableSpellingErrorHighlighting = this._spellingErrorHighlight;
+
+        if ( this._spellingErrorColor != Wordsmith.Configuration.SpellingErrorHighlightColor )
+            Wordsmith.Configuration.SpellingErrorHighlightColor = this._spellingErrorColor;
 
         if (this._dictionaryFilename != Wordsmith.Configuration.DictionaryFile)
         {

--- a/Wordsmith/Helpers/ChatHelper.cs
+++ b/Wordsmith/Helpers/ChatHelper.cs
@@ -37,7 +37,7 @@ public class ChatHelper
             // Add the string to the list with the header and, if offset is not at
             // the end of the string yet, add the continuation marker for the player.
             if (str.Trim().Length > 0)
-                results.Add($"{header} {(OOC ? Wordsmith.Configuration.OocOpeningTag : "")}{str.Trim()}{(OOC ? Wordsmith.Configuration.OocClosingTag : "")}");
+                results.Add($"{(header.Length > 0 ? $"{header} " : "")}{(OOC ? Wordsmith.Configuration.OocOpeningTag : "")}{str.Trim()}{(OOC ? Wordsmith.Configuration.OocClosingTag : "")}");
         }
 
         // If there is more than one result we want to do continuation markers


### PR DESCRIPTION
# Extensions.Extensions.cs
* Fixed a bug that prevented users from entering temporary double spaces (like when attempting to add words.

# dictionaries\lang_en
* Added "plugin" to the dictionary
* Added "kinda" to the dictionary

# Gui.DebugUI.cs
* Added horizontal scrollbar
* changed TextWrapped to Text for better display of chunks
* Added hidden setting to show word indices.

# Gui.ScratchPadUI.cs
* Expanded GetDebugString() function to include more data.
* DrawChunkDisplay now calls DrawChunkItem(...)
*Created DrawChunkItem(string) function to handle better drawing of chunks.
* Created OnTextCallback(ImGuiInputTextCallbackData) function to handle all text callbacks and reposition cursor so that it never stays between wrap markers and new line characters.
* Changed text callback from OnTextEdit to OnTextCallback
* Fixed a bug in OnReplace() that broke wrap markers.
* Removed unnecessary code for fixing broken wrap markers.
* Fixed a bug where replacing a single word with multiple words would cause further replacements to fail.
* Fixed a bug that would cause headers to make the wrong text highlighted for replacement.
* Changed DrawChunkItem debug indices to display based on a hidden setting.

# Helpers.ChatHelper.cs
* Fixed a bug that caused blank headers to start a line with a space.

# Gui.SettingsUI.cs
* Updated DrawSpellCheckTab() to display new options for error highlighting.

# Configuration.cs
* Added setting to enable spelling error highlights.
* Added setting for spelling error highlight color.