### PR TITLE
Changelog:

### DIFF
--- a/Wordsmith/Configuration.cs
+++ b/Wordsmith/Configuration.cs
@@ -34,6 +34,11 @@ public class Configuration : IPluginConfiguration
     public bool IgnoreWordsEndingInHyphen { get; set; } = true;
 
     /// <summary>
+    /// If enabled, uses a custom label layout to display highlighted text.
+    /// </summary>
+    public bool EnableTextHighlighting { get; set; } = true;
+
+    /// <summary>
     /// The spell checker will attempt to delete these punctuation marks from the beginning and end of every word
     /// </summary>
     public string PunctuationCleaningList { get; set; } = ",.'*\"-(){}[]!?<>`~♥@#$%^&*_=+\\/←→↑↓《》■※☀★★☆♡ヅツッシ☀☁☂℃℉°♀♂♠♣♦♣♧®©™€$£♯♭♪✓√◎◆◇♦■□〇●△▽▼▲‹›≤≥<«“”─＼～";
@@ -102,6 +107,20 @@ public class Configuration : IPluginConfiguration
 
     public bool DetectHeaderInput { get; set; } = true;
 
+    public Dictionary<int, Vector4> HeaderColors = new()
+    {
+        {(int)Enums.ChatType.Emote, new(0.9f, 0.9f, 0.9f, 1f) },
+        {(int)Enums.ChatType.Reply, new(1f, 0.35f, 0.6f, 1f) },
+        {(int)Enums.ChatType.Say, new(1f, 1f, 1f, 1f) },
+        {(int)Enums.ChatType.Party, new(0f, 0.5f, 0.6f, 1f) },
+        {(int)Enums.ChatType.FC, new(0.6f, 0.75f, 1f, 1f) },
+        {(int)Enums.ChatType.Shout, new(1f, 0.5f, 0.2f, 1f) },
+        {(int)Enums.ChatType.Yell, new(0.9f, 1f, 0.2f, 1f) },
+        {(int)Enums.ChatType.Tell, new(1f, 0.35f, 0.6f, 1f) },
+        {(int)Enums.ChatType.Echo, new(0.75f, 0.75f, 0.75f, 1f) },
+        {(int)Enums.ChatType.Linkshell, new(0.8f, 1f, 0.6f, 1f) }
+    };
+
     #region Spell Checker Settings
     /// <summary>
     /// Holds the dictionary of words added by the user.
@@ -112,11 +131,6 @@ public class Configuration : IPluginConfiguration
     /// The file to be loaded into Lang dictionary.
     /// </summary>
     public string DictionaryFile { get; set; } = "lang_en";
-
-    /// <summary>
-    /// If enabled, uses a custom label layout to display highlighted text.
-    /// </summary>
-    public bool EnableSpellingErrorHighlighting { get; set; } = true;
 
     public Vector4 SpellingErrorHighlightColor { get; set; } = new( 0.9f, 0.2f, 0.2f, 1f );
     #endregion
@@ -140,7 +154,7 @@ public class Configuration : IPluginConfiguration
         ResearchToTop = true;
 
         // Scratch Pad settings
-        DeleteClosedScratchPads = false;
+        DeleteClosedScratchPads = true;
         IgnoreWordsEndingInHyphen = true;
         PunctuationCleaningList = ",.'*\"-(){}[]!?<>`~♥@#$%^&*_=+\\/";
         ShowTextInChunks = true;
@@ -152,10 +166,23 @@ public class Configuration : IPluginConfiguration
         AutomaticallyClearAfterLastCopy = false;
         ScratchPadTextEnterBehavior = 0;
         ScratchPadMaximumTextLength = 4096;
-        ReplaceDoubleSpaces = true;
-        EnableSpellingErrorHighlighting = true;
-        SpellingErrorHighlightColor = new( 0.9f, 0.2f, 0.2f, 1f );
         DetectHeaderInput = true;
+        ReplaceDoubleSpaces = true;
+        EnableTextHighlighting = true;
+        SpellingErrorHighlightColor = new( 0.9f, 0.2f, 0.2f, 1f );
+        HeaderColors = new()
+        {
+            { (int)Enums.ChatType.Emote, new( 0.9f, 0.9f, 0.9f, 1f ) },
+            { (int)Enums.ChatType.Reply, new( 1f, 0.35f, 0.6f, 1f ) },
+            { (int)Enums.ChatType.Say, new( 1f, 1f, 1f, 1f ) },
+            { (int)Enums.ChatType.Party, new( 0f, 0.5f, 0.6f, 1f ) },
+            { (int)Enums.ChatType.FC, new( 0.6f, 0.75f, 1f, 1f ) },
+            { (int)Enums.ChatType.Shout, new( 1f, 0.5f, 0.2f, 1f ) },
+            { (int)Enums.ChatType.Yell, new( 0.9f, 1f, 0.2f, 1f ) },
+            { (int)Enums.ChatType.Tell, new( 1f, 0.35f, 0.6f, 1f ) },
+            { (int)Enums.ChatType.Echo, new( 0.75f, 0.75f, 0.75f, 1f ) },
+            { (int)Enums.ChatType.Linkshell, new( 0.8f, 1f, 0.6f, 1f ) }
+        };
 
         // Spell Check settings
         DictionaryFile = "lang_en";

--- a/Wordsmith/Data/TextChunk.cs
+++ b/Wordsmith/Data/TextChunk.cs
@@ -8,7 +8,7 @@ internal class TextChunk
     internal string[] Words => this.Text.Split( ' ' );
     internal int WordCount => this.Words.Count();
 
-    internal string CompleteText => $"{(Header.Length > 0 ? $"{Header} " : "")}{OutOfCharacterStartTag}{Text}{OutOfCharacterEndTag}{(ContinuationMarker.Length > 0 ? $" {ContinuationMarker}" : "")}";
+    internal string CompleteText => $"{(Header.Length > 0 ? $"{Header} " : "")}{OutOfCharacterStartTag}{Text.Trim()}{OutOfCharacterEndTag}{(ContinuationMarker.Length > 0 ? $" {ContinuationMarker}" : "")}";
     // Continuation marker
     internal string ContinuationMarker = "";
 

--- a/Wordsmith/Gui/ScratchPadUI.cs
+++ b/Wordsmith/Gui/ScratchPadUI.cs
@@ -499,7 +499,7 @@ internal class ScratchPadUI : Window
                     // Put a separator at the top of the chunk.
                     ImGui.Separator();
 
-                    if (Wordsmith.Configuration.EnableSpellingErrorHighlighting && _corrections.Count > 0)
+                    if (Wordsmith.Configuration.EnableTextHighlighting)
                         DrawChunkItem( _chunks[i], ref offset );
                     else
                     {
@@ -529,12 +529,25 @@ internal class ScratchPadUI : Window
         float width = 0f;
 
         bool sameLine = false;
-        if ( GetFullChatHeader().Length > 0 )
+
+        // Draw header
+        if ( chunk.Header.Length > 0 )
         {
-            ImGui.Text( GetFullChatHeader() );
-            width += ImGui.CalcTextSize( GetFullChatHeader() ).X;
+            ImGui.TextColored( Wordsmith.Configuration.HeaderColors[(int)_chatType], chunk.Header );
+            width += ImGui.CalcTextSize( chunk.Header ).X;
             sameLine = true;
         }
+
+        // Draw OOC
+        if (_useOOC)
+        {
+            ImGui.SameLine( 0, 2 * ImGuiHelpers.GlobalScale );
+            ImGui.Text( Wordsmith.Configuration.OocOpeningTag );
+            width += ImGui.CalcTextSize( Wordsmith.Configuration.OocOpeningTag ).X;
+            sameLine = true;
+        }
+
+        // Draw body
         for (int i = 0; i < chunk.Words.Length; ++i)
         {
             string word = chunk.Words[i];
@@ -555,6 +568,44 @@ internal class ScratchPadUI : Window
             else
                 ImGui.Text(word);
         }
+
+        // Draw OOC
+        if ( _useOOC )
+        {
+            // Calculate new width.
+            width += ImGui.CalcTextSize( Wordsmith.Configuration.OocClosingTag ).X;
+
+            // If width is within bounds then draw same line.
+            if ( width < ImGui.GetWindowContentRegionMax().X )
+                ImGui.SameLine( 0, 2 * ImGuiHelpers.GlobalScale );
+
+            // If out of bounds reset width to new width.
+            else
+                width = ImGui.CalcTextSize( Wordsmith.Configuration.OocClosingTag ).X;
+
+            // Draw text.
+            ImGui.Text( Wordsmith.Configuration.OocClosingTag );
+        }
+
+        if (_chunks.Count > 1)
+        {
+            if ( chunk.ContinuationMarker.Length > 0)
+            {
+                // Calculate new width.
+                width += ImGui.CalcTextSize( chunk.ContinuationMarker ).X;
+
+                // If width is within bounds then draw same line.
+                if ( width < ImGui.GetWindowContentRegionMax().X )
+                    ImGui.SameLine( 0, 2 * ImGuiHelpers.GlobalScale );
+
+                // If out of bounds reset width to new width.
+                else
+                    width = ImGui.CalcTextSize( chunk.ContinuationMarker ).X;
+
+                ImGui.Text( chunk.ContinuationMarker );
+            }
+        }
+        // Draw Continuation marker
         offset += chunk.WordCount;
     }
 


### PR DESCRIPTION
# Data.TextChunk.cs
* Added a Trim() to CompleteText property

# Gui.ScratchPadUI.cs
* Removed need for spelling errors for text colorization.
* Fixed OOC tags not displaying.

# Gui.SettingsUI.cs
* Created Colors tab
* Moved spelling error color option to new Colors Tab.
* Added all color options to Colors tab.

# Configuration.cs
* Changed EnableSpellingErrorHighlighting to EnableTextHighlighting
* Added property HeaderColors