### PR TITLE
# Change log

### DIFF
--- a/Wordsmith/Configuration.cs
+++ b/Wordsmith/Configuration.cs
@@ -5,15 +5,6 @@ namespace Wordsmith;
 [Serializable]
 public sealed class Configuration : IPluginConfiguration
 {
-    /// <summary>
-    /// This is enabled when a save is performed to notify that changes
-    /// have been commited to the configuration file.
-    /// </summary>
-    internal bool RecentlySaved { get; set; } = false;
-
-    public string LastNoticeRead { get; set; } = "";
-
-    public bool NeverShowNotices { get; set; } = false;
 
     /// <summary>
     /// A variable requried by Dalamud. This is used to
@@ -21,6 +12,9 @@ public sealed class Configuration : IPluginConfiguration
     /// are any breaking changes.
     /// </summary>
     public int Version { get; set; } = 0;
+    #region General Settings
+    public int SearchHistoryCount { get; set; } = 10;
+    public bool ResearchToTop { get; set; } = true;
 
     /// <summary>
     /// The Api key used to acces the Merriam-Webster Thesaurus API
@@ -31,12 +25,17 @@ public sealed class Configuration : IPluginConfiguration
     /// A setting that enables the hidden debug UI.
     /// </summary>
     public bool EnableDebug { get; set; } = false;
-    #region Thesaurus Settings
-    //
-    // Thesaurus Settings
-    //
-    public int SearchHistoryCount { get; set; } = 10;
-    public bool ResearchToTop { get; set; } = true;
+    /// <summary>
+    /// This is enabled when a save is performed to notify that changes
+    /// have been commited to the configuration file.
+    /// </summary>
+    internal bool RecentlySaved { get; set; } = false;
+
+    public string LastNoticeRead { get; set; } = "";
+
+    public bool NeverShowNotices { get; set; } = false;
+
+    public bool ShowAdvancedSettings { get; set; } = false;
     #endregion
 
     #region Scratch Pad Settings

--- a/Wordsmith/DataTypes.cs
+++ b/Wordsmith/DataTypes.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Wordsmith.Enums;
+using Wordsmith.Gui;
 
 namespace Wordsmith;
 
@@ -202,6 +203,54 @@ internal sealed class HeaderData
     public override string ToString() => Headstring;
 }
 
+/// <summary>
+/// A class used for comparing multiple pad state elements at once.
+/// </summary>
+internal class PadState
+{
+    internal string ScratchText;
+    internal bool UseOOC;
+    internal HeaderData? Header = null;
+
+    public PadState()
+    {
+        this.ScratchText = "";
+        this.UseOOC = false;
+    }
+
+    public PadState( ScratchPadUI ui )
+    {
+        this.ScratchText = ui.ScratchString;
+        this.UseOOC = ui.UseOOC;
+        this.Header = ui.Header;
+    }
+
+    public static bool operator ==( PadState state, object other ) => state.Equals( other );
+
+    public static bool operator !=( PadState state, object other ) => !state.Equals( other );
+
+    public override bool Equals( object? obj )
+    {
+        if ( obj == null )
+            return false;
+
+        if ( obj is not PadState )
+            return false;
+
+
+        PadState o = (PadState)obj;
+        if ( o.ScratchText != this.ScratchText )
+            return false;
+        if ( o.UseOOC != this.UseOOC )
+            return false;
+        return true;
+    }
+
+    public override int GetHashCode() => HashCode.Combine( this.Header?.ChatType, this.ScratchText, this.UseOOC, this.Header?.TellTarget );
+
+    public override string ToString() => $"{{ ChatType: {this.Header?.ChatType}, ScratchText: \"{this.ScratchText}\", UseOOC: {this.UseOOC}, TellTarget: \"{this.Header?.TellTarget ?? ""}\", CrossWorld: {this.Header?.CrossWorld}, Linkshell: {this.Header?.Linkshell} }}";
+}
+
 internal sealed class TextChunk
 {
     /// <summary>
@@ -217,7 +266,7 @@ internal sealed class TextChunk
     /// <summary>
     /// Text split into words.
     /// </summary>
-    internal Word[] Words => Text.Words();
+    internal List<Word> Words => Text.Words();
 
     /// <summary>
     /// The number of words in the text chunk.
@@ -351,9 +400,9 @@ internal sealed class Word
     public Word() { }
 
     internal string GetString(string s) => GetString(s, 0);
-    internal string GetString(string s, int offset) => StartIndex + offset >= 0 && StartIndex < EndIndex && EndIndex + offset <= s.Unwrap().Length ? s.Unwrap()[(StartIndex + offset)..(EndIndex + offset)] : "";
+    internal string GetString(string s, int offset) => StartIndex + offset >= 0 && StartIndex < EndIndex && EndIndex + offset <= s.Length ? s[(StartIndex + offset)..(EndIndex + offset)] : "";
     internal string GetWordString(string s) => GetWordString(s, 0);
-    internal string GetWordString(string s, int offset) => WordIndex + offset >= 0 && WordLength > 0 && WordIndex + WordLength + offset <= s.Unwrap().Length ? s.Unwrap()[(WordIndex + offset)..(WordIndex + WordLength + offset)] : "";
+    internal string GetWordString(string s, int offset) => WordIndex + offset >= 0 && WordLength > 0 && WordIndex + WordLength + offset <= s.Length ? s[(WordIndex + offset)..(WordIndex + WordLength + offset)] : "";
     internal void Offset(int value)
     {
         StartIndex += value;

--- a/Wordsmith/Extensions.cs
+++ b/Wordsmith/Extensions.cs
@@ -247,11 +247,11 @@ internal static class Extensions
     /// </summary>
     /// <param name="s">The string to parse.</param>
     /// <returns><see cref="Word"/> array containing all words in the string.</returns>
-    internal static Word[] Words( this string s )
+    internal static List<Word> Words( this string s )
     {
         s = s.Unwrap();
         if ( s.Length == 0 )
-            return Array.Empty<Word>();
+            return new();
 
         List<Word> words = new();
 
@@ -316,7 +316,7 @@ internal static class Extensions
             }
             ++len;
         }
-        return words.ToArray();
+        return words;
     }
 
     internal static string? GetTarget( this string s )

--- a/Wordsmith/Helpers/SpellChecker.cs
+++ b/Wordsmith/Helpers/SpellChecker.cs
@@ -7,7 +7,7 @@ internal enum SpellCheckResultState { Cancelled=-1, Exception=-2, Success=0 }
 internal struct SpellCheckResult
 {
     internal SpellCheckResultState State;
-    internal Word[] Words;
+    internal IReadOnlyList<Word> Words;
 }
 internal sealed class SpellChecker
 {   
@@ -26,10 +26,10 @@ internal sealed class SpellChecker
 
         List<Word> results = new();
 
-        Word[] words = str.Words();
+        List<Word> words = str.Words();
 
         // Iterate through all of the words.
-        for ( int i = 0; i < words.Length; ++i )
+        for ( int i = 0; i < words.Count; ++i )
         {
             if ( worker?.CancellationPending ?? false)
                 return;
@@ -92,6 +92,6 @@ internal sealed class SpellChecker
 
         // Done checking all of the words, return the results.
         if ( e != null )
-            e.Result = new SpellCheckResult() { State = SpellCheckResultState.Success, Words = results.ToArray() };
+            e.Result = new SpellCheckResult() { State = SpellCheckResultState.Success, Words = results };
     }
 }

--- a/Wordsmith/Wordsmith.csproj
+++ b/Wordsmith/Wordsmith.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Lady Defile</Authors>
     <Company>DefiledCreations</Company>
-    <Version>1.7.5</Version>
+    <Version>1.7.7</Version>
     <PackageProjectUrl>https://github.com/LadyDefile/Wordsmith</PackageProjectUrl>
     <LangVersion>preview</LangVersion>
     <TargetFramework>net6.0-windows</TargetFramework>
@@ -15,12 +15,6 @@
     <OutputPath>$(AppData)\XIVLauncher\devPlugins\Wordsmith\</OutputPath>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="fonts\**" />
-    <EmbeddedResource Remove="fonts\**" />
-    <None Remove="fonts\**" />
-  </ItemGroup>
 
   <ItemGroup>
     <Content Include="..\images\icon.png" Link="images\icon.png" CopyToOutputDirectory="Always" />


### PR DESCRIPTION
* Made changes to several files to use the new TextChunk.Words property type.

## Configuration.cs
* Added ShowAdvancedSettings

## DataTypes.cs
* Moved PadState class to here
* TextChunk.Words now returns a List<Word>
* Word.GetString(...) Does not automatically unwrap the string anymore.

## Wordsmith.csproj
* Updated version number to 1.7.7
* Removed a reference to a removed folder.

## Gui\
### ScratchPadUI.cs
* Moved PadState class out of file.
* Added more error reporting.
* Updated the UI drawing if a couple elements.
* Using Ctrl+C on a scratchpad input should now copy text unwrapped.
* Fixed a problem with DrawChunkItem that caused the text highlighting loop to use far too many resources.
* Fixed a bug that caused weird word wrapping issues after right-clicking the replace text bar.

### SettingsUI.cs
* Settings now have an advanced setting option to show more advanced options.
* Fixed an issue that caused the `Open Scratch Pads` list to sometimes draw with 0 height.