### PR TITLE
6.5 Fixes

### DIFF
--- a/Wordsmith/Extensions.cs
+++ b/Wordsmith/Extensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Reflection;
 using Dalamud.Interface;
+using Dalamud.Interface.Utility;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
 
@@ -11,7 +12,7 @@ internal static class Extensions
     private const string SPACED_WRAP_MARKER = "\r\r";
     private const string NOSPACE_WRAP_MARKER = "\r";
 
-    internal static float Scale( this int i ) => i * ImGuiHelpers.GlobalScale;
+    internal static float Scale( this int i ) => i * Dalamud.Interface.Utility.ImGuiHelpers.GlobalScale;
 
     #region Collections
     internal static Dictionary<int, Vector4> Clone( this Dictionary<int, Vector4> dict )

--- a/Wordsmith/Gui/DebugUI.cs
+++ b/Wordsmith/Gui/DebugUI.cs
@@ -1,11 +1,16 @@
 ﻿
 #if DEBUG
 using Dalamud.Interface.Windowing;
+using Dalamud.IoC;
+using Dalamud.Logging;
+using Dalamud.Plugin.Services;
 using ImGuiNET;
 namespace Wordsmith.Gui;
 internal sealed class DebugUI : Window
 {
     internal static bool bOverrideSpellcheckLimited = false;
+    [PluginService] private static IPluginLog PluginLog { get; set; } = null!;
+
     public DebugUI() : base( $"{Wordsmith.AppName} - Debug" )
     {
         this.SizeConstraints = new()
@@ -16,7 +21,7 @@ internal sealed class DebugUI : Window
 
         this.Flags |= ImGuiWindowFlags.HorizontalScrollbar;
 
-        PluginLog.LogDebug( $"DebugUI created." );
+        PluginLog.Debug( $"DebugUI created." );
     }
     private static string _consoleInput = "";
     private static int _consolePadNumber = 0;

--- a/Wordsmith/Gui/DebugUI.cs
+++ b/Wordsmith/Gui/DebugUI.cs
@@ -1,6 +1,5 @@
 ﻿
 #if DEBUG
-using Dalamud.Interface;
 using Dalamud.Interface.Windowing;
 using ImGuiNET;
 namespace Wordsmith.Gui;
@@ -11,8 +10,8 @@ internal sealed class DebugUI : Window
     {
         this.SizeConstraints = new()
         {
-            MinimumSize = ImGuiHelpers.ScaledVector2(200, 200),
-            MaximumSize = ImGuiHelpers.ScaledVector2(9999, 9999)
+            MinimumSize = Dalamud.Interface.Utility.ImGuiHelpers.ScaledVector2(200, 200),
+            MaximumSize = Dalamud.Interface.Utility.ImGuiHelpers.ScaledVector2(9999, 9999)
         };
 
         this.Flags |= ImGuiWindowFlags.HorizontalScrollbar;

--- a/Wordsmith/Gui/ErrorWindow.cs
+++ b/Wordsmith/Gui/ErrorWindow.cs
@@ -1,10 +1,13 @@
-﻿using ImGuiNET;
+﻿using Dalamud.IoC;
+using Dalamud.Plugin.Services;
+using ImGuiNET;
 
 
 namespace Wordsmith.Gui;
 
 internal sealed class ErrorWindow : MessageBox
 {
+    [PluginService] private static IPluginLog PluginLog { get; set; } = null!;
     private const string message = "Wordsmith has encountered an error.\nCopy error dump to clipboard and open bug report page?\n\nWARNING: I WILL be able to see anything and everything\ntyped as part of the log.";
     internal Dictionary<string, object> ErrorDump = new Dictionary<string, object>();
     public ErrorWindow( Dictionary<string, object> dump ) : base( $"Wordsmith Error", message, ButtonStyle.YesNo, Callback) { this.ErrorDump = dump; }
@@ -28,7 +31,7 @@ internal sealed class ErrorWindow : MessageBox
             }
             catch ( Exception e )
             {
-                PluginLog.LogError( e.ToString() );
+                PluginLog.Error( e.ToString() );
             }
         }
         WordsmithUI.RemoveWindow( mb );

--- a/Wordsmith/Gui/ScratchPadHelpUI.cs
+++ b/Wordsmith/Gui/ScratchPadHelpUI.cs
@@ -1,12 +1,12 @@
 ﻿using Dalamud.Interface;
 using Dalamud.Interface.Windowing;
 using ImGuiNET;
-
+using Dalamud.Interface.Utility;
 namespace Wordsmith.Gui;
 
 internal sealed class ScratchPadHelpUI : Window
 {
-    internal static ImGuiScene.TextureWrap? MerriamWebsterLogo = null;
+    internal static Dalamud.Interface.Internal.IDalamudTextureWrap? MerriamWebsterLogo = null;
 
     internal ScratchPadHelpUI() : base($"{Wordsmith.AppName} - Help")
     {

--- a/Wordsmith/Gui/ScratchPadUI.cs
+++ b/Wordsmith/Gui/ScratchPadUI.cs
@@ -3,7 +3,7 @@ using Dalamud.Interface.Windowing;
 using ImGuiNET;
 using Wordsmith.Enums;
 using Wordsmith.Helpers;
-
+using Dalamud.Interface.Utility;
 namespace Wordsmith.Gui;
 
 internal sealed class ScratchPadUI : Window

--- a/Wordsmith/Gui/ScratchPadUI.cs
+++ b/Wordsmith/Gui/ScratchPadUI.cs
@@ -4,10 +4,16 @@ using ImGuiNET;
 using Wordsmith.Enums;
 using Wordsmith.Helpers;
 using Dalamud.Interface.Utility;
+using Dalamud.IoC;
+using Dalamud.Plugin.Services;
+
 namespace Wordsmith.Gui;
 
 internal sealed class ScratchPadUI : Window
 {
+    [PluginService] private static IPluginLog PluginLog { get; set; } = null!;
+
+
     #region Constants
     internal const int CORRECTIONS_FOUND = -1;
     internal const int CHECKING_SPELLING = 1;
@@ -1312,7 +1318,7 @@ internal sealed class ScratchPadUI : Window
                     while ( data->CursorPos < data->BufTextLen && data->Buf[(data->CursorPos - 1 > 0 ? data->CursorPos - 1 : 0)] == '\r' )
                     {
                         data->CursorPos++;
-                        PluginLog.LogVerbose( $"Moved cursor to the right." );
+                        PluginLog.Verbose( $"Moved cursor to the right." );
                     }
                 }
                 if ( data->CursorPos > 0 )
@@ -1320,7 +1326,7 @@ internal sealed class ScratchPadUI : Window
                     while ( data->CursorPos > 0 && data->Buf[data->CursorPos - 1] == '\r' )
                     {
                         data->CursorPos--;
-                        PluginLog.LogVerbose( "Moved cursor to the left." );
+                        PluginLog.Verbose( "Moved cursor to the left." );
                     }
                 }
             }

--- a/Wordsmith/Gui/SettingsUI.cs
+++ b/Wordsmith/Gui/SettingsUI.cs
@@ -4,11 +4,18 @@ using ImGuiNET;
 using Wordsmith.Enums;
 using Wordsmith.Helpers;
 using Dalamud.Interface.Utility;
+using Dalamud.Logging;
+using Dalamud.IoC;
+using Dalamud.Plugin.Services;
+
 namespace Wordsmith.Gui;
 
 internal sealed class SettingsUI : Window
 {
     private const int MAX_MARKER_FRAME_Y = 10;
+
+    [PluginService] private static IPluginLog PluginLog { get; set; } = null!;
+
 
     /// <summary>
     /// Gets the available size for tab pages while leaving room for the footer.
@@ -1289,7 +1296,7 @@ internal sealed class SettingsUI : Window
 
     public void OnException(Exception e)
     {
-        PluginLog.LogError( e.ToString() );
+        PluginLog.Error( e.ToString() );
         this.IsOpen = false;
         Dictionary<string, object> dump = this.Dump();
         dump["Exception"] = new Dictionary<string, object>()

--- a/Wordsmith/Gui/SettingsUI.cs
+++ b/Wordsmith/Gui/SettingsUI.cs
@@ -3,7 +3,7 @@ using Dalamud.Interface.Windowing;
 using ImGuiNET;
 using Wordsmith.Enums;
 using Wordsmith.Helpers;
-
+using Dalamud.Interface.Utility;
 namespace Wordsmith.Gui;
 
 internal sealed class SettingsUI : Window

--- a/Wordsmith/Gui/ThesaurusUI.cs
+++ b/Wordsmith/Gui/ThesaurusUI.cs
@@ -3,7 +3,7 @@ using Dalamud.Interface;
 using Dalamud.Interface.Windowing;
 using Wordsmith.Helpers;
 using Wordsmith;
-
+using Dalamud.Interface.Utility;
 namespace Wordsmith.Gui;
 
 internal sealed class ThesaurusUI : Window, IDisposable

--- a/Wordsmith/Helpers/Git.cs
+++ b/Wordsmith/Helpers/Git.cs
@@ -1,4 +1,7 @@
 ﻿using System.Net.Http;
+using Dalamud.IoC;
+using Dalamud.Logging;
+using Dalamud.Plugin.Services;
 using Newtonsoft.Json;
 
 namespace Wordsmith.Helpers;
@@ -7,6 +10,7 @@ internal sealed class Git
 {
     private const string MANIFEST_JSON_URL = "https://raw.githubusercontent.com/LadyDefile/WordsmithDictionaries/main/manifest.json";
     private const string LIBRARY_FILE_URL = "https://raw.githubusercontent.com/LadyDefile/WordsmithDictionaries/main/library";
+    [PluginService] private static IPluginLog PluginLog { get; set; } = null!;
 
     internal class DictionaryDoesNotExistException : Exception
     { }
@@ -43,7 +47,7 @@ internal sealed class Git
                 {
                     // Disable the IfModifiedSince header to avoid a 304 response error.
                     client.DefaultRequestHeaders.IfModifiedSince = null;
-                    PluginLog.LogError( $"Failed to get manifest. Tries remaining {tries}. Error: {e.Message}\nRaw: {raw}" );
+                    PluginLog.Error( $"Failed to get manifest. Tries remaining {tries}. Error: {e.Message}\nRaw: {raw}" );
                 }
             }
         }
@@ -71,7 +75,7 @@ internal sealed class Git
                 {
                     // Disable refresh request.
                     client.DefaultRequestHeaders.IfModifiedSince = null;
-                    PluginLog.LogError( $"Error loading dictionary from web: {e.Message}" );
+                    PluginLog.Error( $"Error loading dictionary from web: {e.Message}" );
                 }
             }            
         }

--- a/Wordsmith/Helpers/Lang.cs
+++ b/Wordsmith/Helpers/Lang.cs
@@ -1,4 +1,7 @@
 ﻿
+using Dalamud.IoC;
+using Dalamud.Logging;
+using Dalamud.Plugin.Services;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -7,6 +10,9 @@ namespace Wordsmith.Helpers;
 public static class Lang
 {
     private static HashSet<string> _dictionary = new();
+
+    [PluginService] private static IPluginLog PluginLog { get; set; } = null!;
+
 
     private static bool _enabled = false;
     /// <summary>
@@ -133,14 +139,14 @@ public static class Lang
         catch (HttpRequestException e)
         {
             if (e.StatusCode != System.Net.HttpStatusCode.OK)
-                PluginLog.LogError($"Unable to load language from {Wordsmith.Configuration.DictionaryFile}. Http Status Code: {e.StatusCode}");
+                PluginLog.Error($"Unable to load language from {Wordsmith.Configuration.DictionaryFile}. Http Status Code: {e.StatusCode}");
             else
-                PluginLog.LogError($"Unable to load language from {Wordsmith.Configuration.DictionaryFile}.\n{e}");
+                PluginLog.Error($"Unable to load language from {Wordsmith.Configuration.DictionaryFile}.\n{e}");
             return false;
         }
         catch (Exception e)
         {
-            PluginLog.LogError($"Unable to load language from {Wordsmith.Configuration.DictionaryFile}.\n{e}");
+            PluginLog.Error($"Unable to load language from {Wordsmith.Configuration.DictionaryFile}.\n{e}");
             return false;
         }
     }
@@ -177,7 +183,7 @@ public static class Lang
         }
         catch (Exception e)
         {
-            PluginLog.LogError($"Unable to load language from {Wordsmith.Configuration.DictionaryFile}.\n{e}");
+            PluginLog.Error($"Unable to load language from {Wordsmith.Configuration.DictionaryFile}.\n{e}");
         }
         return false;
     }
@@ -389,7 +395,7 @@ public static class Lang
         }
         catch ( Exception e )
         {
-            PluginLog.LogError( e.ToString() );
+            PluginLog.Error( e.ToString() );
         }
         return results;
     }

--- a/Wordsmith/Helpers/MerriamWebsterAPI.cs
+++ b/Wordsmith/Helpers/MerriamWebsterAPI.cs
@@ -2,6 +2,9 @@
 using System.ComponentModel;
 using Newtonsoft.Json;
 using System.Xml.Linq;
+using Dalamud.Logging;
+using Dalamud.Plugin.Services;
+using Dalamud.IoC;
 
 namespace Wordsmith.Helpers;
 
@@ -13,6 +16,8 @@ internal sealed class MerriamWebsterAPI : IDisposable
     public float Progress => _progress;
 
     internal ApiState State { get; private set; }
+
+    [PluginService] private IPluginLog PluginLog { get; set; } = null!;
 
     private List<WordSearchResult> _history = new List<WordSearchResult>();
 
@@ -40,7 +45,7 @@ internal sealed class MerriamWebsterAPI : IDisposable
 
         // Add the latest to the history
         this._history.Insert(0, entry);
-        PluginLog.LogDebug($"Added {entry.Query} to history.");
+        PluginLog.Debug($"Added {entry.Query} to history.");
 
         // Setting search history length to zero will just make it unlimited.
         if ( Wordsmith.Configuration.SearchHistoryCount == 0 )
@@ -123,19 +128,19 @@ internal sealed class MerriamWebsterAPI : IDisposable
                                 {
                                     if ( id.Value.ToLower() != query.ToLower() )
                                     {
-                                        PluginLog.LogDebug( $"Element ID did not match query: {id}" );
+                                        PluginLog.Debug( $"Element ID did not match query: {id}" );
                                         continue;
                                     }
                                 }
                                 else
                                 {
-                                    PluginLog.LogDebug( $"Failed to get ID element: {meta}" );
+                                    PluginLog.Debug( $"Failed to get ID element: {meta}" );
                                     continue;
                                 }
                             }
                             else
                             {
-                                PluginLog.LogDebug( $"Failed to get meta: {entry}" );
+                                PluginLog.Debug( $"Failed to get meta: {entry}" );
                                 continue;
                             }
 
@@ -211,7 +216,7 @@ internal sealed class MerriamWebsterAPI : IDisposable
                 }
                 catch ( Exception ex )
                 {
-                    PluginLog.LogError( ex.Message );
+                    PluginLog.Error( ex.Message );
                 }
             }
             else
@@ -248,7 +253,7 @@ internal sealed class MerriamWebsterAPI : IDisposable
             if ( this.History.Count == 0)
                 return false;
 
-            PluginLog.LogDebug($"Checking History for {query}");
+            PluginLog.Debug($"Checking History for {query}");
 
             this._progress = 0f;
             // If searching the same thing twice, return
@@ -277,7 +282,7 @@ internal sealed class MerriamWebsterAPI : IDisposable
         }
         catch (Exception ex)
         {
-            PluginLog.LogError(ex.Message);
+            PluginLog.Error(ex.Message);
         }
         return false;
     }
@@ -293,7 +298,7 @@ internal sealed class MerriamWebsterAPI : IDisposable
         }
         catch ( Exception e )
         {
-            PluginLog.LogError( e.Message );
+            PluginLog.Error( e.Message );
         }
     }
 }

--- a/Wordsmith/Wordsmith.cs
+++ b/Wordsmith/Wordsmith.cs
@@ -41,7 +41,7 @@ using Dalamud.IoC;
 using Dalamud.Plugin;
 using Wordsmith.Gui;
 using Wordsmith.Helpers;
-
+using Dalamud.Plugin.Services;
 namespace Wordsmith;
 
 public sealed class Wordsmith : IDalamudPlugin
@@ -90,10 +90,10 @@ public sealed class Wordsmith : IDalamudPlugin
     internal static DalamudPluginInterface PluginInterface { get; private set; } = null!;
 
     [PluginService]
-    internal static CommandManager CommandManager { get; private set; } = null!;
+    internal static ICommandManager CommandManager { get; private set; } = null!;
 
     [PluginService]
-    internal static DataManager DataManager { get; private set; } = null!;
+    internal static IDataManager DataManager { get; private set; } = null!;
     #endregion
 
     /// <summary>

--- a/Wordsmith/Wordsmith.csproj
+++ b/Wordsmith/Wordsmith.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Lady Defile</Authors>
     <Company>DefiledCreations</Company>
-    <Version>1.9.0</Version>
+    <Version>1.9.2</Version>
     <PackageProjectUrl>https://github.com/LadyDefile/Wordsmith</PackageProjectUrl>
     <LangVersion>latest</LangVersion>
     <TargetFramework>net7.0-windows</TargetFramework>
@@ -33,7 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.10" />
+    <PackageReference Include="DalamudPackager" Version="2.1.12" />
+    <PackageReference Include="XivCommon" Version="9.0.0" />
     <Reference Include="FFXIVClientStructs">
       <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
       <Private>false</Private>

--- a/Wordsmith/Wordsmith.csproj
+++ b/Wordsmith/Wordsmith.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Lady Defile</Authors>
     <Company>DefiledCreations</Company>
-    <Version>1.9.2</Version>
+    <Version>1.9.0</Version>
     <PackageProjectUrl>https://github.com/LadyDefile/Wordsmith</PackageProjectUrl>
     <LangVersion>latest</LangVersion>
     <TargetFramework>net7.0-windows</TargetFramework>
@@ -34,7 +34,6 @@
 
   <ItemGroup>
     <PackageReference Include="DalamudPackager" Version="2.1.12" />
-    <PackageReference Include="XivCommon" Version="9.0.0" />
     <Reference Include="FFXIVClientStructs">
       <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
       <Private>false</Private>

--- a/Wordsmith/Wordsmith.json
+++ b/Wordsmith/Wordsmith.json
@@ -1,8 +1,8 @@
 {
   "Author": "Lady Defile",
-  "Name": "Wordsmith",
+  "Name": "Wordsmith (Unofficial)",
   "Punchline": "A roleplay thesaurus and scratch pad.",
-  "Description": "Wordsmith is a text editor with roleplayers in mind. It automatically breaks your text up for easy copy/paste, has advanced features, spellcheck, and even a thesaurus.",
+  "Description": "An unofficial fork of Wordsmith for Patch 6.5, the Text Editor built with roleplayers in mind. It automatically breaks your text up for easy copy/paste, has advanced features, spellcheck, and even a thesaurus.",
   "InternalName": "Wordsmith",
   "ApplicableVersion": "any",
   "Tags": [

--- a/Wordsmith/Wordsmith.json
+++ b/Wordsmith/Wordsmith.json
@@ -1,8 +1,8 @@
 {
   "Author": "Lady Defile",
-  "Name": "Wordsmith (Unofficial)",
+  "Name": "Wordsmith",
   "Punchline": "A roleplay thesaurus and scratch pad.",
-  "Description": "An unofficial fork of Wordsmith for Patch 6.5, the Text Editor built with roleplayers in mind. It automatically breaks your text up for easy copy/paste, has advanced features, spellcheck, and even a thesaurus.",
+  "Description": "Wordsmith is a text editor with roleplayers in mind. It automatically breaks your text up for easy copy/paste, has advanced features, spellcheck, and even a thesaurus.",
   "InternalName": "Wordsmith",
   "ApplicableVersion": "any",
   "Tags": [

--- a/Wordsmith/WordsmithUI.cs
+++ b/Wordsmith/WordsmithUI.cs
@@ -44,6 +44,16 @@ internal static class WordsmithUI
     private static List<Window> _add_queue = new();
     #endregion
 
+    internal static Window GetWindowByName(String name)
+    {
+        foreach (Window w in _windowSystem.Windows)
+        {
+            if (w.WindowName.ToLower().Equals(name.ToLower()))
+                return w;
+        }
+        return null;
+    }
+
     /// <summary>
     /// Adds a window object to the <see cref="WindowSystem"/>.
     /// If the window lock is engaged the window will be stored in a
@@ -57,7 +67,7 @@ internal static class WordsmithUI
             return;
 
         // Check if the Window already exists.
-        Window? w_test = _windowSystem.GetWindow(w.WindowName);
+        Window? w_test = GetWindowByName(w.WindowName);
 
         // If the window already exists in the Window System show the
         // existing Window and dispose of the given Window object.
@@ -108,7 +118,7 @@ internal static class WordsmithUI
     /// </summary>
     /// <param name="windowName"><see cref="string"/> name of the Window.</param>
     /// <returns><see langword="true"/> if the <see cref="Window"/> exists.</returns>
-    internal static bool Contains( string windowName ) => _windowSystem.GetWindow( windowName ) != null;
+    internal static bool Contains( string windowName ) => GetWindowByName( windowName ) != null;
 
     /// <summary>
     /// Disposes of all child objects.
@@ -186,7 +196,7 @@ internal static class WordsmithUI
         }
     }
 
-    internal static Window? GetWindow( string name ) => _windowSystem.GetWindow( name );
+    internal static Window? GetWindow( string name ) => GetWindowByName( name );
 
     /// <summary>
     /// Removes the window from the <see cref="WindowSystem"/> and <see cref="List{T}"/>.

--- a/Wordsmith/WordsmithUI.cs
+++ b/Wordsmith/WordsmithUI.cs
@@ -1,6 +1,8 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Dalamud.Interface.Windowing;
+using Dalamud.IoC;
+using Dalamud.Plugin.Services;
 using ImGuiNET;
 using Wordsmith.Gui;
 using static Wordsmith.Gui.MessageBox;
@@ -12,6 +14,9 @@ internal static class WordsmithUI
     internal static Clock Clock { get; private set; } = new();
 
     internal static float LineHeight { get; private set; }
+
+    [PluginService] private static IPluginLog PluginLog { get; set; } = null!;
+
 
     /// <summary>
     /// Returns a readonly list containing all currently registered windows.
@@ -44,7 +49,7 @@ internal static class WordsmithUI
     private static List<Window> _add_queue = new();
     #endregion
 
-    internal static Window GetWindowByName(String name)
+    internal static Window? GetWindowByName(String name)
     {
         foreach (Window w in _windowSystem.Windows)
         {
@@ -174,7 +179,7 @@ internal static class WordsmithUI
                     w.IsOpen = false;
             }
             // Log the error.
-            PluginLog.LogError( $"There was an exception in the WindowSystem draw process. All windows have been hidden for now.\nError: {e}\nMessage: {e.Message}" );
+            PluginLog.Error( $"There was an exception in the WindowSystem draw process. All windows have been hidden for now.\nError: {e}\nMessage: {e.Message}" );
 
             // Attempt to add an error window to be displayed. If it fails to draw we'll end up back here anyway.
             if ( !Contains("WordsmithUI Error") )
@@ -219,7 +224,7 @@ internal static class WordsmithUI
             }
             catch ( Exception e )
             {
-                PluginLog.LogError( $"ERROR: {e.Message}\n{e}" );
+                PluginLog.Error($"ERROR: {e.Message}\n{e}");
             }
         }
         // If the windows are locked queue deletion for next cycle

--- a/Wordsmith/packages.lock.json
+++ b/Wordsmith/packages.lock.json
@@ -7,12 +7,6 @@
         "requested": "[2.1.12, )",
         "resolved": "2.1.12",
         "contentHash": "Sc0PVxvgg4NQjcI8n10/VfUQBAS4O+Fw2pZrAqBdRMbthYGeogzu5+xmIGCGmsEZ/ukMOBuAqiNiB5qA3MRalg=="
-      },
-      "XivCommon": {
-        "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "avaBp3FmSCi/PiQhntCeBDYOHejdyTWmFtz4pRBVQQ8vHkmRx+YTk1la9dkYBMlXxRXKckEdH1iI1Fu61JlE7w=="
       }
     }
   }

--- a/Wordsmith/packages.lock.json
+++ b/Wordsmith/packages.lock.json
@@ -4,9 +4,15 @@
     "net7.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.10, )",
-        "resolved": "2.1.10",
-        "contentHash": "S6NrvvOnLgT4GDdgwuKVJjbFo+8ZEj+JsEYk9ojjOR/MMfv1dIFpT8aRJQfI24rtDcw1uF+GnSSMN4WW1yt7fw=="
+        "requested": "[2.1.12, )",
+        "resolved": "2.1.12",
+        "contentHash": "Sc0PVxvgg4NQjcI8n10/VfUQBAS4O+Fw2pZrAqBdRMbthYGeogzu5+xmIGCGmsEZ/ukMOBuAqiNiB5qA3MRalg=="
+      },
+      "XivCommon": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "avaBp3FmSCi/PiQhntCeBDYOHejdyTWmFtz4pRBVQQ8vHkmRx+YTk1la9dkYBMlXxRXKckEdH1iI1Fu61JlE7w=="
       }
     }
   }


### PR DESCRIPTION
- Replaced GetWindow calls with a GetWindowByName function in WordsmithUI.cs (Inefficient but easiest just to get things working with the change to WindowSystem)
- CommandManager -> ICommandManager
- DataManager -> IDataManager
- PluginLog -> IPluginLog